### PR TITLE
feat: improve dark mode accessibility

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="light dark">
     <title>PARKINGNOW</title>
 
     <!-- Favicon -->

--- a/docs/js/theme-switcher.js
+++ b/docs/js/theme-switcher.js
@@ -1,14 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
     const themeToggleButtons = document.querySelectorAll('.theme-toggle'); // Selects both desktop and mobile buttons
-    const lightIconClass = 'theme-icon--light';
-    const darkIconClass = 'theme-icon--dark';
 
     function applyTheme(theme) {
-        if (theme === 'dark') {
-            document.documentElement.classList.add('dark-mode-active');
-        } else {
-            document.documentElement.classList.remove('dark-mode-active');
-        }
+        const enableDark = theme === 'dark';
+        document.documentElement.classList.toggle('dark-mode-active', enableDark);
+
+        // Update accessible labels for all toggle buttons
+        themeToggleButtons.forEach(btn => {
+            btn.setAttribute('aria-label', enableDark ? 'Switch to light mode' : 'Switch to dark mode');
+        });
         // Icon visibility is handled by CSS based on .dark-mode-active
     }
 


### PR DESCRIPTION
## Summary
- ensure browsers recognize dark mode support via color-scheme meta tag
- update theme toggles to announce current mode for screen readers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3be9dc608331b0cacc12a8bbdfc6